### PR TITLE
change inheritance from require('events').EventEmitter

### DIFF
--- a/lib/json-sieve.js
+++ b/lib/json-sieve.js
@@ -23,14 +23,17 @@
 // is "pretty-printed" with whitespace.
 //
 // ### Source
-var events = require('events')
+var EventEmitter = require('events').EventEmitter
   , util = require('util')
   ;
 
 
 function JSONSieve() {
+  EventEmitter.apply(this, arguments)
   this.lineBuffer_ = '';
 }
+
+util.inherits(JSONSieve, EventEmitter);
 
 // After construction, chunked data may be passed to `observe()`.
 JSONSieve.prototype.observe = function(dataStr) {
@@ -97,7 +100,5 @@ JSONSieve.prototype.close = function(cb) {
   }
   return (cb && cb());
 };
-
-util.inherits(JSONSieve, events.EventEmitter);
 
 module.exports = JSONSieve;


### PR DESCRIPTION
hey @mayanklahiri, cool module!

i tried to run the example using node 4

``` js
var superchild = require('superchild');
var child = superchild('ls -lh');
child.on('stdout_line', function(line) {
  console.log('[stdout]: ', line);
});
```

but for some reason it didn't work:

```
/.../node_modules/superchild/lib/superchild.js:223
    sieve.observe(dataStr);
          ^

TypeError: sieve.observe is not a function
    at Socket.<anonymous> (/.../node_modules/superchild/lib/superchild.js:223:11)
    at emitOne (events.js:77:13)
    at Socket.emit (events.js:169:7)
    at readableAddChunk (_stream_readable.js:146:16)
    at Socket.Readable.push (_stream_readable.js:110:10)
```

so i changed how `JSONSieve` inherits from `require('events').EventEmitter` and now it seems to work. :)
